### PR TITLE
added backwards compatible firmware logic

### DIFF
--- a/custom_components/span_panel/config_flow.py
+++ b/custom_components/span_panel/config_flow.py
@@ -190,12 +190,22 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         span_api = create_api_controller(self.hass, self.host)
         panel_status = await span_api.get_status_data()
 
-        # Reprompt until we are able to do proximity auth
-        proximity_verified = panel_status.proximity_proven
-        if proximity_verified is False:
-            return self.async_show_form(
-                step_id="auth_proximity"
-            )
+        #Check if running firmware newer or older than r202342
+        if panel_status.proximity_proven is not None:
+
+             # Reprompt until we are able to do proximity auth for new firmware
+            proximity_verified = panel_status.proximity_proven
+            if proximity_verified is False:
+                return self.async_show_form(
+                    step_id="auth_proximity"
+                )
+        else:
+            # Reprompt until we are able to do proximity auth for old firmware
+            remaining_presses = panel_status.remaining_auth_unlock_button_presses
+            if remaining_presses != 0:
+                return self.async_show_form(
+                    step_id="auth_proximity",
+                )
 
         # Ensure token is valid
         self.access_token = await span_api.get_access_token()

--- a/custom_components/span_panel/span_panel_status.py
+++ b/custom_components/span_panel/span_panel_status.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any
+from typing import Any, Union
 
 SYSTEM_DOOR_STATE_CLOSED = "CLOSED"
 SYSTEM_DOOR_STATE_OPEN = "OPEN"
@@ -14,11 +14,12 @@ class SpanPanelStatus:
     serial_number: str
     model: str
     door_state: str
-    proximity_proven: bool
     uptime: int
     is_ethernet_connected: bool
     is_wifi_connected: bool
     is_cellular_connected: bool
+    proximity_proven: Union[bool, None] = None
+    remaining_auth_unlock_button_presses: Union[int, None] = None
 
     @property
     def is_door_closed(self) -> bool:
@@ -26,17 +27,37 @@ class SpanPanelStatus:
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> "SpanPanelStatus":
-        return SpanPanelStatus(
-            firmware_version=data["software"]["firmwareVersion"],
-            update_status=data["software"]["updateStatus"],
-            env=data["software"]["env"],
-            manufacturer=data["system"]["manufacturer"],
-            serial_number=data["system"]["serial"],
-            model=data["system"]["model"],
-            door_state=data["system"]["doorState"],
-            proximity_proven=data["system"]["proximityProven"],
-            uptime=data["system"]["uptime"],
-            is_ethernet_connected=data["network"]["eth0Link"],
-            is_wifi_connected=data["network"]["wlanLink"],
-            is_cellular_connected=data["network"]["wwanLink"],
-        )
+        if "proximityProven" in data["system"]:
+            sps = SpanPanelStatus(
+                firmware_version=data["software"]["firmwareVersion"],
+                update_status=data["software"]["updateStatus"],
+                env=data["software"]["env"],
+                manufacturer=data["system"]["manufacturer"],
+                serial_number=data["system"]["serial"],
+                model=data["system"]["model"],
+                door_state=data["system"]["doorState"],
+                uptime=data["system"]["uptime"],
+                is_ethernet_connected=data["network"]["eth0Link"],
+                is_wifi_connected=data["network"]["wlanLink"],
+                is_cellular_connected=data["network"]["wwanLink"],
+                proximity_proven=data["system"]["proximityProven"],
+            )
+        else:
+            sps = SpanPanelStatus(
+                firmware_version=data["software"]["firmwareVersion"],
+                update_status=data["software"]["updateStatus"],
+                env=data["software"]["env"],
+                manufacturer=data["system"]["manufacturer"],
+                serial_number=data["system"]["serial"],
+                model=data["system"]["model"],
+                door_state=data["system"]["doorState"],
+                uptime=data["system"]["uptime"],
+                is_ethernet_connected=data["network"]["eth0Link"],
+                is_wifi_connected=data["network"]["wlanLink"],
+                is_cellular_connected=data["network"]["wwanLink"],
+                remaining_auth_unlock_button_presses=data["system"][
+                "remainingAuthUnlockButtonPresses"
+                ],
+            )
+
+        return sps


### PR DESCRIPTION
backwards compatible config flow logic for firmware pre and post API changes in spanos2/r202342/04 since some panels can take days or weeks to auto-update, and some users have multi-panel installs that are out of sync.

- added logic to load either proximityProven or remainingAuthUnlockButtonPresses, depending on presence

- updated config flow to use the method relevant to which value exists, instead of assuming only the new method exists

(These changes can likely be reverted to a new-only flow after a sensible amount of time, say maybe 1 year.)